### PR TITLE
fix: vite hmr update error on certain circumstances

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -82,3 +82,9 @@ export function createHashStore<T = Hash>(
 		return hashValues
 	}
 }
+
+if (import.meta.hot) {
+    import.meta.hot.on('vite:beforeUpdate', () => {
+        isStoreInitialized = false;
+    });
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -84,7 +84,7 @@ export function createHashStore<T = Hash>(
 }
 
 if (import.meta.hot) {
-    import.meta.hot.on('vite:beforeUpdate', () => {
-        isStoreInitialized = false;
-    });
+	import.meta.hot.on('vite:beforeUpdate', () => {
+		isStoreInitialized = false
+	})
 }


### PR DESCRIPTION
In certain circumstances (ex. [Musicale](https://github.com/musicale)) Vite failed resetting the singleton pattern throwing a "multiple instance" error, while it was just an HMR update.

This should be now fixed.
